### PR TITLE
remove extra import library.

### DIFF
--- a/notebook/source/monai_dicom.py
+++ b/notebook/source/monai_dicom.py
@@ -5,7 +5,6 @@ import argparse
 import json
 import logging
 import os
-import sagemaker_containers
 import sys
 import torch
 import torch.distributed as dist

--- a/notebook/source/monai_dicom.py
+++ b/notebook/source/monai_dicom.py
@@ -142,7 +142,15 @@ def train(args):
         epoch_loss /= step
         epoch_loss_values.append(epoch_loss)
         logger.info(f"epoch {epoch + 1} average loss: {epoch_loss:.4f}")
-        
+    save_model(model, args.model_dir)
+
+
+def save_model(model, model_dir):
+    logger.info("Saving the model.")
+    path = os.path.join(model_dir, 'model.pth')
+    # recommended way from http://pytorch.org/docs/master/notes/serialization.html
+    torch.save(model.cpu().state_dict(), path)
+
     
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change deals with a problem below;

1. monai_dicom.py has extra library, sagemaker_containers that can not be imported in the latest SageMaker Docker Image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
