### PR TITLE
Label adjustment (review) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python and Jupyter:
+__pycache__/
+.ipynb_checkpoints
+
+# NodeJS
+**/node_modules/**
+
+# Operating Systems:
+.DS_Store

--- a/sagemaker-groundtruth/sagemaker_resources.yaml
+++ b/sagemaker-groundtruth/sagemaker_resources.yaml
@@ -150,6 +150,17 @@ Resources:
                 }
                 if labels is not None:
                     output['taskInput']['labels'] = labels
+                prev_annotation = event['dataObject'].get('prevAnnotation')
+                if prev_annotation is not None:
+                    try:
+                        output['taskInput']['prevAnnotation'] = (
+                            prev_annotation['annotationsFromAllWorkers'][0]['annotationData']['content']
+                        )
+                    except Exception as e:
+                        logger.exception(
+                            'Failed to include previous annotation in task object - check previous job output '
+                            'structure is as expected'
+                        )
                 logger.info(json.dumps(output, indent=2))
                 # If neither source nor source-ref specified, mark the annotation failed
                 if task_object is None:

--- a/sagemaker-groundtruth/template.liquid.html
+++ b/sagemaker-groundtruth/template.liquid.html
@@ -109,9 +109,32 @@ SPDX-License-Identifier: MIT-0 -->
         if (!prevAnnRaw) return;
         console.log('Previous Annotations:', prevAnnRaw);
         const prevAnnotations = JSON.parse(prevAnnRaw);
+
+        // First the disease checkboxes:
+        try {
+            if (prevAnnotations.disease) {
+                const chkContainer = document.getElementById('labelsSelection');
+                Object.keys(prevAnnotations.disease).forEach((disease) => {
+                    if (prevAnnotations.disease[disease]) {
+                        // querySelector method here assumes no disease label ever contains quote "
+                        const checkbox = chkContainer.querySelector(`input[value="${disease}"]`);
+                        if (checkbox) {
+                            checkbox.setAttribute('checked', null);  // Set checked
+                        } else {
+                            console.warn(
+                                `Previously annotated disease "${disease}" is not in current job.`
+                            );
+                        }
+                    }
+                });
+            }
+        } catch (err) {
+            console.warn("Couldn't load previous disease labels", err);
+        }
+
+        // Then highlighted regions of interest:
         const prevToolData = JSON.parse(prevAnnotations.labels);
         const roi = prevToolData.ROI;
-
         // Need to translate back from saved SMGT annotations to cornerstone tool state:
         let roiToolType;
         let roiData;

--- a/sagemaker-groundtruth/template.liquid.html
+++ b/sagemaker-groundtruth/template.liquid.html
@@ -21,7 +21,7 @@ SPDX-License-Identifier: MIT-0 -->
 </div>
 
 <crowd-form>
-    <input name="labels" id="labels" type="hidden">
+    <input name="labels" id="labels" type="hidden" value="{{ task.input.prevAnnotation }}" />
 
     <!-- Prevent crowd-form from creating its own button -->
     <crowd-button id="submit" form-action="submit" style="display: none;"></crowd-button>
@@ -82,9 +82,18 @@ SPDX-License-Identifier: MIT-0 -->
         }
     });
 
+    function getLabelClasses() {
+        const rawLabels = document.getElementById('document-labels').innerText.trim();
+        try {
+            return JSON.parse(rawLabels);
+        } catch (err) {
+            console.log("Couldn't parse raw labels as JSON - interpreting as comma-separated string");
+            return rawLabels.split(',');
+        }
+    }
+
     function createLabelButtons() {
-        var str = document.getElementById('document-labels').innerText.trim();
-        var labels = str.split(",")
+        const labels = getLabelClasses();
 
         for (i = 0; i < labels.length; i++) {
             document.getElementById('labelsSelection').innerHTML += '<label class="container">'+labels[i]+'<input type="checkbox" name="disease" value="'+labels[i]+'"><span class="checkmark"></span></label>'
@@ -93,13 +102,48 @@ SPDX-License-Identifier: MIT-0 -->
     }
 
     var loaded = false;
+    var element = document.getElementById('dicomImage');
+
+    function loadPrevAnnotations() {
+        const prevAnnRaw = document.getElementById('labels').value;
+        if (!prevAnnRaw) return;
+        console.log('Previous Annotations:', prevAnnRaw);
+        const prevAnnotations = JSON.parse(prevAnnRaw);
+        const prevToolData = JSON.parse(prevAnnotations.labels);
+        const roi = prevToolData.ROI;
+
+        // Need to translate back from saved SMGT annotations to cornerstone tool state:
+        let roiToolType;
+        let roiData;
+        if ('vertices' in roi) {
+            roiToolType = 'freehand';
+            roiData = {
+                handles: roi.vertices,
+            };
+        } else {
+            // TODO: Detect ellipses properly
+            // This is hacky because we don't currently save enough in the SMGT result (below) to
+            // actually know whether the rectangle or ellipse ROI tool was used. Would be better to
+            // save a bit more information in the SMGT result - which would enable us to properly
+            // reconstruct here.
+            roiToolType = 'rectangleRoi';
+            roiData = {
+                handles: {
+                    start: roi.start,
+                    end: roi.end,
+                    textBox: { boundingBox: roi.boundingBox },
+                },
+            };
+        }
+        
+        cornerstoneTools.addToolState(element, roiToolType, roiData);
+    }
+
     function downloadAndView() {
         let url = document.getElementById('document-image').innerText.trim();
 
         // prefix the url with wadouri: so cornerstone can find the image loader
         url = "wadouri:" + url;
-        // image enable the dicomImage element and activate a few tools
-        var element = document.getElementById('dicomImage');
 
         try {
             var start = new Date().getTime();
@@ -120,6 +164,7 @@ SPDX-License-Identifier: MIT-0 -->
                     cornerstoneTools.rectangleRoi.enable(element);
                     loaded = true;
                 }
+                loadPrevAnnotations();
             }, function(err) {
                 alert(err);
             });
@@ -129,7 +174,6 @@ SPDX-License-Identifier: MIT-0 -->
         }
     }
 
-    var element = document.getElementById('dicomImage');
     cornerstone.enable(element);
 
     document.addEventListener("DOMContentLoaded", function(){


### PR DESCRIPTION
**Issue #, if available:** #8

**Description of changes:**

- An initial sketch (not ready for merge yet) at how it might look to implement support for using the DICOM SMGT UI template to review and adjust existing annotations, instead of labelling from scratch.
- Update class label loading to also accept JSON (instead of comma-separated strings), as JSON may be a more natural choice to use in JSONL input manifests.
- Add a basic gitignore to help avoid accidental check-in of build artifacts and other unnecessary files.

**Limitations / Open questions:**

1. Currently the name of the previous annotation attribute on input manifest is assumed hard-coded to `prevAnnotations` (meaning users need to transform the output manifest of their initial labelling job before using it as the input for an adjustment job). An alternative would be to dynamically create the final `liquid.html` file at the point of use, and accept a parameter controlling what this attribute name is / whether it exists: For example as used ([here](https://github.com/aws-samples/amazon-textract-transformer-pipeline/blob/cdafb5f358a3bb791c85d78bc7902ef645edbe0e/notebooks/util/smgt.py#L264) in the "Set up the custom task template" section of [this notebook](https://github.com/aws-samples/amazon-textract-transformer-pipeline/blob/main/notebooks/1.%20Data%20Preparation.ipynb)). But this adds an extra layer of abstraction.
    - This also affects the pre-labelling Lambda function as currently written
2. The data currently saved to SMGT output by the template is not actually sufficient to fully reconstruct labelling tool state: For example there's nothing to differentiate between rectangle and ellipse ROIs. For this initial draft I chose to just hack around it rather than change the output format of the job, but I think it'd be better to extend the job output?
3. The consolidation Lambda here doesn't actually do any consolidation really... It just outputs the list of all annotations. So for review I simply took the assumption that exactly one worker had annotated the original. Generally I think there's a fair amount of refactoring that could be done of what's in the objects passed between each stage to try and tidy up?

Assumptions of current draft:

An original input manifest entry looks something like (in single line):

```js
{
  "source": "59475f39-919111b5-4f82c54c-09303b20-12345678",
  "labels": "Atelectasis,Cardiomegaly,No Finding"
  // Or "labels": ["Atelectasis", "Cardiomegaly, "No Finding"]
}
```

A second-round (review) input manifest entry looks something like (in single line):

```js
{
  "source":"59475f39-919111b5-4f82c54c-09303b20-12345678",
  "labels": "Atelectasis,Cardiomegaly,No Finding",
  // Or "labels": ["Atelectasis", "Cardiomegaly, "No Finding"]
  "prevAnnotation": {
    "annotationsFromAllWorkers": [
      // Exactly one previous worker:
      {
        "workerId":"private.us-east-1.1234567890abcdef",
        "annotationData": {
          // content is stringified (which I think we could avoid), and
          // content.label is again stringified within that
          "content": "{\"disease\":{\"Atelectasis\":false,\"Cardiomegaly\":false,\"No Finding\":true},\"labels\":\"{\\\"label\\\":[\\\"Pleural Other\\\"],\\\"imageurl\\\":\\\"https://abcdef1234567890.cloudfront.net/instances/59475f39-919111b5-4f82c54c-09303b20-12345678/file\\\",\\\"ROI\\\":{\\\"start\\\":{\\\"x\\\":234.4744744744745,\\\"y\\\":206.9525502064565,\\\"highlight\\\":true,\\\"active\\\":false},\\\"end\\\":{\\\"x\\\":292.9009009009009,\\\"y\\\":238.472069725976,\\\"highlight\\\":true,\\\"active\\\":false},\\\"boundingBox\\\":{\\\"width\\\":130.11666870117188,\\\"height\\\":65,\\\"left\\\":381,\\\"top\\\":257.19999694824224}}}\"}"
        }
      }
    ]
  },
  // Optional, ignored -metadata (would have originally been
  // 'actual-smgt-job-1-name-metadata' in job 1 output manifest)
  "prevAnnotation-metadata": {
    "type":"groundtruth/custom",
    "job-name":"actual-smgt-job-1-name",
    "human-annotated":"yes",
    "creation-date":"2022-04-22T06:00:25.913000"
  }
}
```

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
